### PR TITLE
Testing/cross process locking

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - aot_monorepo_compat
+      - testing/cross-process-locking
   workflow_dispatch:
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ doc/api/
 
 # Internal Testing & Analysis
 ./_scripts
+bin/test/primary_semaphore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,6 @@
 - TODO: In code dartdoc comments for pub.dev API documentation
 - TODO: GH Actions for Publishing to pub.dev
 
+## 1.0.0-beta.7
+- Added cross process unit tests with dart AOT compiled binaries that all try to leverage the same named lock
+- FIX: Fixed a bug where the SemaphoreIdentity wasn't getting the Semaphore's address assigned to it

--- a/bin/test/primary_semaphore.dart
+++ b/bin/test/primary_semaphore.dart
@@ -10,7 +10,9 @@ main(List<String> args) async {
 
   String tracker = args.elementAt(3);
 
-  // stdout.writeln('Creating semaphore with name: $name');
+  stdout.writeln('Child Process Parameters Lock Delay: $lock_delay, Unlock Delay: $unlock_delay, Tracker: $tracker, PID: $pid, Name: $name');
+
+  stdout.writeln('Creating semaphore with name: $name');
 
   final NativeSemaphore sem = NativeSemaphore.instantiate(name: name)..open();
 
@@ -26,15 +28,15 @@ main(List<String> args) async {
 
   sem.unlock();
 
-  // stdout.writeln('Semaphore unlocked with name: $name');
+  stdout.writeln('Semaphore unlocked with name: $name');
 
   sem.close();
 
-  // stdout.writeln('Semaphore closed with name: $name');
+  stdout.writeln('Semaphore closed with name: $name');
 
   sem.unlink();
 
-  // stdout.writeln('Semaphore unlinked with name: $name');
+  stdout.writeln('Semaphore unlinked with name: $name');
 
   exit(0);
 

--- a/bin/test/primary_semaphore.dart
+++ b/bin/test/primary_semaphore.dart
@@ -1,0 +1,41 @@
+import 'dart:io' show exit, pid, stdout;
+
+import 'package:runtime_native_semaphores/runtime_native_semaphores.dart';
+
+main(List<String> args) async {
+  String name = args.elementAt(0);
+
+  int lock_delay = int.parse(args.elementAt(1));
+  int unlock_delay = int.parse(args.elementAt(2));
+
+  String tracker = args.elementAt(3);
+
+  // stdout.writeln('Creating semaphore with name: $name');
+
+  final NativeSemaphore sem = NativeSemaphore.instantiate(name: name)..open();
+
+  await Future.delayed(Duration(seconds: lock_delay));
+
+  Stopwatch stopwatch = Stopwatch()..start();
+  sem.lock();
+  stopwatch.stop();
+
+  stdout.writeln('Child Process $tracker $pid Locking semaphore with name $name took: [${stopwatch.elapsed.inSeconds}] seconds');
+
+  await Future.delayed(Duration(seconds: unlock_delay));
+
+  sem.unlock();
+
+  // stdout.writeln('Semaphore unlocked with name: $name');
+
+  sem.close();
+
+  // stdout.writeln('Semaphore closed with name: $name');
+
+  sem.unlink();
+
+  // stdout.writeln('Semaphore unlinked with name: $name');
+
+  exit(0);
+
+}

--- a/lib/ffigen/hello_library_arm64/CMakeLists.txt
+++ b/lib/ffigen/hello_library_arm64/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(CMAKE_OSX_ARCHITECTURES "arm64")
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+project(hello_library_arm64 VERSION 1.0.0 LANGUAGES C)
+add_library(hello_library_arm64 SHARED hello.c hello.def)
+add_executable(hello_test hello.c)
+
+set_target_properties(hello_library_arm64 PROPERTIES
+    PUBLIC_HEADER hello.h
+    VERSION ${PROJECT_VERSION}
+    SOVERSION 1
+    OUTPUT_NAME "hello"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "Hex_Identity_ID_Goes_Here"
+)

--- a/lib/src/native_semaphore.dart
+++ b/lib/src/native_semaphore.dart
@@ -207,7 +207,7 @@ class NativeSemaphore<
   @protected
   bool willAttemptLockAcrossProcesses() => throw UnimplementedError();
   @protected
-  bool lockAcrossProcesses({bool blocking = true}) => throw UnimplementedError();
+  bool lockAcrossProcesses({bool blocking = true, Duration? timeout}) => throw UnimplementedError();
   @protected
   bool lockAttemptAcrossProcessesSucceeded({required int attempt}) => throw UnimplementedError();
 

--- a/lib/src/semaphore_identity.dart
+++ b/lib/src/semaphore_identity.dart
@@ -49,9 +49,11 @@ class SemaphoreIdentity {
   String get process => SemaphoreIdentities.process;
 
   //  Gets set when the semaphore is opened
-  late final String _address;
+  late final int _address;
 
-  String get address => _address;
+  int get address => _address;
+
+  set address(int value) => !LatePropertyAssigned<int>(() => _address) ? _address = value : _address;
 
   late final String _name;
 

--- a/lib/src/unix_semaphore.dart
+++ b/lib/src/unix_semaphore.dart
@@ -75,6 +75,7 @@ class UnixSemaphore<
     if (verbose) print("Attempting to [open()] semaphore: ${name}");
 
     if (!semaphore.isSet) _semaphore = sem_open(_identifier, UnixSemOpenMacros.O_CREAT, MODE_T_PERMISSIONS.RECOMMENDED, UnixSemOpenMacros.VALUE_RECOMMENDED);
+    identity.address = _semaphore.address;
 
     if (verbose) print("Semaphore [open()] attempt response: ${semaphore}");
 
@@ -111,7 +112,7 @@ class UnixSemaphore<
   }
 
   @override
-  bool lockAcrossProcesses({bool blocking = true}) {
+  bool lockAcrossProcesses({bool blocking = true, Duration? timeout}) {
     if (!willAttemptLockAcrossProcesses()) return false;
 
     if (verbose) print("Attempting [lockAcrossProcesses()]: IDENTITY: ${identity.uuid} BLOCKING: $blocking");

--- a/lib/src/windows_semaphore.dart
+++ b/lib/src/windows_semaphore.dart
@@ -104,7 +104,7 @@ class WindowsSemaphore<
   }
 
   @override
-  bool lockAcrossProcesses({bool blocking = true}) {
+  bool lockAcrossProcesses({bool blocking = true, Duration? timeout}) {
     if (!willAttemptLockAcrossProcesses()) return false;
 
     if (verbose) print("Attempting [lockAcrossProcesses()]: IDENTITY: ${identity.uuid} BLOCKING: $blocking");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,11 @@
 name: runtime_native_semaphores
 homepage: https://pieces.app
 repository: https://github.com/open-runtime/native_semaphores
-version: 1.0.0-beta.6
+version: 1.0.0-beta.7
 description: A library for creating and managing named semaphores in Dart using FFI across macOS, Linux, and Windows.
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
+
 
 # Explicitly declare that this package works on all desktop platforms.
 platforms:

--- a/test/cross_process_semaphore_test.dart
+++ b/test/cross_process_semaphore_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async' show Future, StreamController, StreamIterator, StreamSink, StreamSubscription, StreamTransformer;
+import 'dart:convert' show jsonDecode, jsonEncode, utf8;
+import 'dart:io' show File, Process, ProcessResult, ProcessSignal, ProcessStartMode, pid, sleep, stdin, stdout;
+import 'dart:isolate' show Isolate, ReceivePort, SendPort;
+import 'dart:math' show Random;
+
+import 'package:runtime_native_semaphores/runtime_native_semaphores.dart' show NativeSemaphore;
+import 'package:safe_int_id/safe_int_id.dart' show safeIntId;
+import 'package:runtime_native_semaphores/src/native_semaphore_types.dart' show NS;
+import 'package:test/test.dart' show Timeout, equals, everyElement, expect, group, isTrue, setUp, test;
+
+String processRequest(Map<String, dynamic> request) {
+  // Implement your logic here
+  return 'Processed from parent: ${request['data']}';
+}
+
+void main() async {
+
+  String process_name = 'bin/test/primary_semaphore';
+
+  setUp(() async {
+
+    File primary_semaphore_executable = File(process_name);
+
+    if(!primary_semaphore_executable.existsSync()) {
+
+      ProcessResult compiling_primary_semaphore_executable = await Process.run('dart', ['compile', 'exe', 'bin/test/primary_semaphore.dart', '-o', process_name]);
+
+      print('Successfully compiled primary_semaphore_executable: ${compiling_primary_semaphore_executable.stdout}');
+
+      primary_semaphore_executable.existsSync() || (throw Exception("Primary semaphore executable should exist."));
+    } else {
+      print('Primary semaphore was found and already compiled. Be sure you haven\'t made changes and need to compile again.');
+    }
+  });
+
+
+  group('Testing Cross-Process Named Semaphore', () {
+    test('Several Processes Coordinated Leveraging Named Locks', () async {
+      String name = '${safeIntId.getId()}_named_sem';
+
+      final NativeSemaphore sem = NativeSemaphore.instantiate(name: name)
+        ..open()
+        ..lock();
+
+      Future.delayed(Duration(seconds: 4), () => sem.unlock());
+
+      // It takes about 1 second rounded up to spin up each process here i.e. the first lock should take about 3 seconds to acquire given the delay above
+      // The second process should take about 5 seconds to acquire the lock given the unlock delay of 4 seconds of the first process and the roughly 1 second it takes to spin up the first process
+      List<ProcessResult> processes = await Future.wait([
+        // Initial process with lock delay of 0 locks right away
+        Process.run(process_name, [name, /*lock delay */ '0', /* unlock delay */ '4', 'first'], runInShell: true),
+        // Secondary process with lock delay of 2 i.e. 2 seconds into the first processes unlock delay
+        Process.run(process_name, [name, /*lock delay */ '2', /* unlock delay */ '0', 'second'], runInShell: true)
+      ]);
+
+      // Start with unlock delay of 2
+      ProcessResult running_primary_semaphore_executable = processes.first;
+      // Start with unlock delay of 4
+      ProcessResult running_secondary_semaphore_executable = processes.last;
+
+      // use regex to parse the number [x] out of this return string "Child Process first 55852 Locking semaphore with name 44314234863597_named_sem took: [3] seconds"
+      RegExp lock_time = RegExp(r"Locking semaphore with name \d+_named_sem took: \[(\d+)\] seconds");
+
+      int? primary_lock_time = int.tryParse(lock_time.firstMatch(running_primary_semaphore_executable.stdout)?.group(1) ?? '-1');
+      int? secondary_lock_time = int.tryParse(lock_time.firstMatch(running_secondary_semaphore_executable.stdout)?.group(1) ?? '-1');
+
+      print('primary_lock_time: $primary_lock_time seconds to lock');
+      print('secondary_lock_time: $secondary_lock_time seconds to lock');
+
+      expect(primary_lock_time, equals(3));
+      expect(secondary_lock_time, equals(5));
+
+      expect(sem.close(), isTrue);
+      expect(sem.unlink(), isTrue);
+
+    }, timeout: Timeout(Duration(seconds: 60)));
+  });
+}

--- a/test/cross_process_semaphore_test.dart
+++ b/test/cross_process_semaphore_test.dart
@@ -17,7 +17,7 @@ String processRequest(Map<String, dynamic> request) {
 
 void main() async {
 
-  String process_name = Platform.isWindows ?   'bin\test\primary_semaphore.exe' : 'bin/test/primary_semaphore';
+  String process_name =  'bin${Platform.pathSeparator}test${Platform.pathSeparator}primary_semaphore${Platform.isWindows ? '.exe' : ''}';
 
   setUp(() async {
 
@@ -25,7 +25,7 @@ void main() async {
 
     if(!primary_semaphore_executable.existsSync()) {
 
-      ProcessResult compiling_primary_semaphore_executable = await Process.run('dart', ['compile', 'exe', 'bin${Platform.pathSeparator}test${Platform.pathSeparator}primary_semaphore.dart', '-o', process_name]);
+      ProcessResult compiling_primary_semaphore_executable = Process.runSync('dart', ['compile', 'exe', 'bin${Platform.pathSeparator}test${Platform.pathSeparator}primary_semaphore.dart', '-o', process_name]);
 
       print('Successfully compiled primary_semaphore_executable: ${compiling_primary_semaphore_executable.stdout}');
 
@@ -59,6 +59,9 @@ void main() async {
       ProcessResult running_primary_semaphore_executable = processes.first;
       // Start with unlock delay of 4
       ProcessResult running_secondary_semaphore_executable = processes.last;
+
+      print('${Platform.lineTerminator}Primary Process:${Platform.lineTerminator}${Platform.lineTerminator} ${running_primary_semaphore_executable.stdout} ${Platform.lineTerminator}');
+      print('${Platform.lineTerminator}Secondary Process:${Platform.lineTerminator}${Platform.lineTerminator} ${running_secondary_semaphore_executable.stdout} ${Platform.lineTerminator}${Platform.lineTerminator}');
 
       // use regex to parse the number [x] out of this return string "Child Process first 55852 Locking semaphore with name 44314234863597_named_sem took: [3] seconds"
       RegExp lock_time = RegExp(r"Locking semaphore with name \d+_named_sem took: \[(\d+)\] seconds");

--- a/test/cross_process_semaphore_test.dart
+++ b/test/cross_process_semaphore_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async' show Future, StreamController, StreamIterator, StreamSink, StreamSubscription, StreamTransformer;
 import 'dart:convert' show jsonDecode, jsonEncode, utf8;
-import 'dart:io' show File, Process, ProcessResult, ProcessSignal, ProcessStartMode, pid, sleep, stdin, stdout;
+import 'dart:io' show File, Platform, Process, ProcessResult, ProcessSignal, ProcessStartMode, pid, sleep, stdin, stdout;
 import 'dart:isolate' show Isolate, ReceivePort, SendPort;
 import 'dart:math' show Random;
 
@@ -16,7 +16,7 @@ String processRequest(Map<String, dynamic> request) {
 
 void main() async {
 
-  String process_name = 'bin/test/primary_semaphore';
+  String process_name = Platform.isWindows ?   'bin/test/primary_semaphore.exe' : 'bin/test/primary_semaphore';
 
   setUp(() async {
 

--- a/test/cross_process_semaphore_test.dart
+++ b/test/cross_process_semaphore_test.dart
@@ -17,7 +17,7 @@ String processRequest(Map<String, dynamic> request) {
 
 void main() async {
 
-  String process_name = Platform.isWindows ?   'bin/test/primary_semaphore.exe' : 'bin/test/primary_semaphore';
+  String process_name = Platform.isWindows ?   'bin\test\primary_semaphore.exe' : 'bin/test/primary_semaphore';
 
   setUp(() async {
 
@@ -25,7 +25,7 @@ void main() async {
 
     if(!primary_semaphore_executable.existsSync()) {
 
-      ProcessResult compiling_primary_semaphore_executable = await Process.run('dart', ['compile', 'exe', 'bin/test/primary_semaphore.dart', '-o', process_name]);
+      ProcessResult compiling_primary_semaphore_executable = await Process.run('dart', ['compile', 'exe', 'bin${Platform.pathSeparator}test${Platform.pathSeparator}primary_semaphore.dart', '-o', process_name]);
 
       print('Successfully compiled primary_semaphore_executable: ${compiling_primary_semaphore_executable.stdout}');
 
@@ -50,9 +50,9 @@ void main() async {
       // The second process should take about 5 seconds to acquire the lock given the unlock delay of 4 seconds of the first process and the roughly 1 second it takes to spin up the first process
       List<ProcessResult> processes = await Future.wait([
         // Initial process with lock delay of 0 locks right away
-        Process.run(process_name, [name, /*lock delay */ '0', /* unlock delay */ '4', 'first'], runInShell: true),
+        Process.run(process_name, [name, /*lock delay */ '0', /* unlock delay */ '4', 'first']),
         // Secondary process with lock delay of 2 i.e. 2 seconds into the first processes unlock delay
-        Process.run(process_name, [name, /*lock delay */ '2', /* unlock delay */ '0', 'second'], runInShell: true)
+        Process.run(process_name, [name, /*lock delay */ '2', /* unlock delay */ '0', 'second'])
       ]);
 
       // Start with unlock delay of 2

--- a/test/cross_process_semaphore_test.dart
+++ b/test/cross_process_semaphore_test.dart
@@ -7,6 +7,7 @@ import 'dart:math' show Random;
 import 'package:runtime_native_semaphores/runtime_native_semaphores.dart' show NativeSemaphore;
 import 'package:safe_int_id/safe_int_id.dart' show safeIntId;
 import 'package:runtime_native_semaphores/src/native_semaphore_types.dart' show NS;
+import 'package:test/expect.dart';
 import 'package:test/test.dart' show Timeout, equals, everyElement, expect, group, isTrue, setUp, test;
 
 String processRequest(Map<String, dynamic> request) {
@@ -68,12 +69,12 @@ void main() async {
       print('primary_lock_time: $primary_lock_time seconds to lock');
       print('secondary_lock_time: $secondary_lock_time seconds to lock');
 
-      expect(primary_lock_time, equals(3));
-      expect(secondary_lock_time, equals(5));
+      expect(primary_lock_time, equals(anyOf([3, 4])));
+      expect(secondary_lock_time, equals(anyOf([4, 5, 6])));
 
       expect(sem.close(), isTrue);
       expect(sem.unlink(), isTrue);
 
-    }, timeout: Timeout(Duration(seconds: 60)));
+    });
   });
 }

--- a/test/semaphore_test.dart
+++ b/test/semaphore_test.dart
@@ -11,12 +11,12 @@ void main() {
   group('Testing Cross-Isolate Named Semaphore', () {
     test('Several Isolates Accessing Same Named Semaphore, waiting random durations and then unlocking.', () async {
       Future<bool> spawn_isolate(String name, int id) async {
-        // throw Exception("This is a test for the workstream pattern engine");
         // The entry point for the isolate
         void isolate_entrypoint(SendPort sender) {
           // Captures the call frame here, put right right inside the method entrypoint
 
           final NS sem = NativeSemaphore.instantiate(name: name, verbose: true);
+
 
           bool opened = sem.open();
           opened || (throw Exception("Open in isolate $id should have succeeded"));


### PR DESCRIPTION
- Added unit tests for cross process locking i.e. two dart AOT binaries are ran with Process.run and they all share the same lock. The test ensures that it takes a certain amount of time for each lock to lock based on the previous locks' artificial 'unlock' delay. 