### PR TITLE
Fix: Add linux-arm64 ABI mapping for mode_t

### DIFF
--- a/lib/src/ffi/unix.dart
+++ b/lib/src/ffi/unix.dart
@@ -28,6 +28,7 @@ typedef sem_t = Int;
   Abi.macosX64: Uint16(),
   Abi.linuxX64: Uint16(),
   Abi.linuxIA32: Uint16(),
+  Abi.linuxArm64: Uint16(),
 })
 final class mode_t extends AbiSpecificInteger {
   const mode_t();


### PR DESCRIPTION
Fix: Add linux-arm64 ABI mapping for mode_t

*Problem:*

When compiling Dart applications using dart compile exe on linux-arm64 (e.g., GitHub Actions ubuntu-24.04-arm runner), the build fails with:

```
Error: AbiSpecificInteger 'mode_t' is missing mapping for 'linux_arm64'.
Error: AOT compilation failed
```

*Solution:*

Added Abi.linuxArm64: Uint16() to the @AbiSpecificIntegerMapping for mode_t in lib/src/ffi/unix.dart, consistent with other Linux architectures.

Testing:

Successfully built and ran on linux-arm64 via GitHub Actions
