### PR TITLE
chore: integrate runtime_ci_tooling for CI/CD and autodoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.bot_check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check for release bot commit
+        id: bot_check
+        run: |
+          AUTHOR=$(git log -1 --format='%an')
+          MSG=$(git log -1 --format='%s')
+          echo "Commit author: $AUTHOR"
+          echo "Commit subject: $MSG"
+          if [[ "$AUTHOR" == "github-actions[bot]" ]] || [[ "$MSG" == *"[skip ci]"* ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release bot commit detected — skipping CI."
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  analyze-and-test:
+    needs: pre-check
+    if: needs.pre-check.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - name: Cache Dart analysis
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.dartServer
+          key: ${{ runner.os }}-dart-analysis-${{ hashFiles('**/*.dart', '**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-analysis-
+
+      - name: Analyze
+        run: dart run runtime_ci_tooling:manage_cicd analyze
+
+      - name: Test
+        run: dart run runtime_ci_tooling:manage_cicd test

--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,98 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Check for triage trigger
+        id: trigger
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            if echo "$COMMENT_BODY" | grep -qi "@gemini-cli"; then
+              echo "run=true" >> $GITHUB_OUTPUT
+            else
+              echo "run=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v6.0.2
+        if: steps.trigger.outputs.run == 'true'
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        if: steps.trigger.outputs.run == 'true'
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        if: steps.trigger.outputs.run == 'true'
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        if: steps.trigger.outputs.run == 'true'
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        if: steps.trigger.outputs.run == 'true'
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+        if: steps.trigger.outputs.run == 'true'
+
+      - uses: actions/setup-node@v6.2.0
+        if: steps.trigger.outputs.run == 'true'
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+        if: steps.trigger.outputs.run == 'true'
+
+      - name: Cache Go modules (GitHub MCP server)
+        if: steps.trigger.outputs.run == 'true'
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - name: Run triage
+        if: steps.trigger.outputs.run == 'true'
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dart run runtime_ci_tooling:triage_cli ${{ github.event.issue.number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,702 @@
+name: Release Pipeline
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+env:
+  GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+
+jobs:
+  # ============================================================================
+  # Gate: Verify CI passed AND commit is not from release bot
+  # ============================================================================
+  pre-check:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check for release bot commit
+        id: gate
+        run: |
+          AUTHOR=$(git log -1 --format='%an')
+          MSG=$(git log -1 --format='%s')
+          echo "Commit author: $AUTHOR"
+          echo "Commit subject: $MSG"
+          if [[ "$AUTHOR" == "github-actions[bot]" ]] || [[ "$MSG" == *"[skip ci]"* ]] || [[ "$MSG" == *"bot(release)"* ]]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release bot commit — skipping release pipeline."
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ============================================================================
+  # Job 1: Determine Version
+  # ============================================================================
+  determine-version:
+    needs: pre-check
+    if: needs.pre-check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      prev_tag: ${{ steps.version.outputs.prev_tag }}
+      should_release: ${{ steps.version.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - name: Determine version
+        id: version
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dart run runtime_ci_tooling:manage_cicd determine-version --output-github-actions
+
+      - name: Upload version bump rationale
+        if: steps.version.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: version-bump-rationale
+          path: version_bumps/
+          retention-days: 90
+
+      - name: Upload CI/CD audit trail
+        if: steps.version.outputs.should_release == 'true'
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: cicd-audit-determine-version
+          path: .cicd_runs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # ============================================================================
+  # Job 2: Pre-Release Triage
+  # ============================================================================
+  pre-release-triage:
+    needs: determine-version
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - name: Pre-release triage
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd pre-release-triage \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+          # Find manifest from .cicd_runs/ audit trail
+          MANIFEST=$(find .cicd_runs -name "issue_manifest.json" -type f 2>/dev/null | sort -r | head -1)
+          if [ -n "$MANIFEST" ]; then
+            cp "$MANIFEST" /tmp/issue_manifest.json
+          else
+            echo '{"version":"${{ needs.determine-version.outputs.new_version }}","github_issues":[],"sentry_issues":[],"cross_repo_issues":[]}' > /tmp/issue_manifest.json
+          fi
+
+      - uses: actions/upload-artifact@v6.0.0
+        with:
+          name: issue-manifest
+          path: /tmp/issue_manifest.json
+          retention-days: 1
+
+      - name: Upload CI/CD audit trail
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: cicd-audit-pre-release-triage
+          path: .cicd_runs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # ============================================================================
+  # Job 3: Stage 1 -- Explorer Agent
+  # ============================================================================
+  explore-changes:
+    needs: [determine-version, pre-release-triage]
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - uses: actions/download-artifact@v7.0.0
+        with:
+          name: issue-manifest
+          path: /tmp/
+
+      - name: Stage 1 Explorer
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd explore \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+      - name: Create fallback stage1 artifacts if missing
+        run: |
+          [ -f /tmp/commit_analysis.json ] || echo '{"commits":[],"note":"Gemini unavailable - no analysis generated"}' > /tmp/commit_analysis.json
+          [ -f /tmp/pr_data.json ] || echo '{"pull_requests":[],"note":"Gemini unavailable"}' > /tmp/pr_data.json
+          [ -f /tmp/breaking_changes.json ] || echo '{"breaking_changes":[],"note":"Gemini unavailable"}' > /tmp/breaking_changes.json
+
+      - uses: actions/upload-artifact@v6.0.0
+        with:
+          name: stage1-artifacts
+          path: |
+            /tmp/commit_analysis.json
+            /tmp/pr_data.json
+            /tmp/breaking_changes.json
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload CI/CD audit trail
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: cicd-audit-explore
+          path: .cicd_runs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # ============================================================================
+  # Job 4: Stage 2 -- Composer Agent + Documentation
+  # ============================================================================
+  compose-artifacts:
+    needs: [determine-version, explore-changes]
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: stage1-artifacts
+          path: /tmp/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: issue-manifest
+          path: /tmp/
+
+      - name: Stage 2 Composer
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd compose \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+      - name: Documentation update
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd documentation \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+      - name: Autodoc (module documentation)
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dart run runtime_ci_tooling:manage_cicd autodoc
+
+      - uses: actions/upload-artifact@v6.0.0
+        with:
+          name: composed-artifacts
+          path: |
+            CHANGELOG.md
+            README.md
+            docs/
+            .runtime_ci/autodoc.json
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload CI/CD audit trail
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: cicd-audit-compose
+          path: .cicd_runs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # ============================================================================
+  # Job 5: Stage 3 -- Release Notes Author
+  # ============================================================================
+  release-notes:
+    needs: [determine-version, explore-changes, pre-release-triage, compose-artifacts]
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      # Download ALL previous stage artifacts for context
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: stage1-artifacts
+          path: /tmp/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: issue-manifest
+          path: /tmp/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: composed-artifacts
+          path: ./artifacts/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: version-bump-rationale
+          path: ./version_bumps/
+
+      # Copy CHANGELOG from compose stage so release notes can reference it
+      - name: Apply compose artifacts
+        run: |
+          if [ -f ./artifacts/CHANGELOG.md ]; then
+            cp ./artifacts/CHANGELOG.md ./CHANGELOG.md
+          fi
+          if [ -f ./artifacts/README.md ]; then
+            cp ./artifacts/README.md ./README.md
+          fi
+
+      - name: Stage 3 Release Notes Author
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd release-notes \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+      - name: Consolidate release notes
+        run: |
+          VERSION="${{ needs.determine-version.outputs.new_version }}"
+          mkdir -p "release_notes/v${VERSION}"
+          cp /tmp/release_notes_body.md "release_notes/v${VERSION}/" 2>/dev/null || true
+          cp /tmp/migration_guide.md "release_notes/v${VERSION}/" 2>/dev/null || true
+          echo "Contents of release_notes/v${VERSION}/:"
+          ls -la "release_notes/v${VERSION}/" 2>/dev/null || echo "(empty)"
+
+      - uses: actions/upload-artifact@v6.0.0
+        with:
+          name: release-notes-artifacts
+          path: release_notes/
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Upload CI/CD audit trail
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: cicd-audit-release-notes
+          path: .cicd_runs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # ============================================================================
+  # Job 6: Create Release
+  # ============================================================================
+  create-release:
+    needs: [determine-version, compose-artifacts, release-notes]
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: true
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: composed-artifacts
+          path: ./artifacts/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: release-notes-artifacts
+          path: ./release-notes-artifacts/
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: version-bump-rationale
+          path: ./version_bumps/
+
+      - name: Download CI/CD audit trails
+        continue-on-error: true
+        uses: actions/download-artifact@v7.0.0
+        with:
+          pattern: cicd-audit-*
+          path: .cicd_runs_incoming/
+          merge-multiple: false
+
+      - name: Prepare artifacts
+        run: |
+          VERSION="${{ needs.determine-version.outputs.new_version }}"
+          mkdir -p ./artifacts ./version_bumps "./release_notes/v${VERSION}"
+
+          if [ -d "./release-notes-artifacts/v${VERSION}" ]; then
+            cp -r "./release-notes-artifacts/v${VERSION}/"* "./release_notes/v${VERSION}/" 2>/dev/null || true
+          elif [ -d "./release-notes-artifacts" ]; then
+            FOUND=$(find ./release-notes-artifacts -name "release_notes.md" -type f 2>/dev/null | head -1)
+            if [ -n "$FOUND" ]; then
+              cp "$(dirname "$FOUND")"/* "./release_notes/v${VERSION}/" 2>/dev/null || true
+            fi
+          fi
+
+          if [ -f "./release_notes/v${VERSION}/release_notes_body.md" ]; then
+            cp "./release_notes/v${VERSION}/release_notes_body.md" /tmp/release_notes_body.md
+          elif [ -f "./release_notes/v${VERSION}/release_notes.md" ]; then
+            cp "./release_notes/v${VERSION}/release_notes.md" /tmp/release_notes_body.md
+          fi
+
+          echo "Release notes contents:"
+          ls -la "./release_notes/v${VERSION}/" 2>/dev/null || echo "(empty)"
+
+      - name: Merge CI/CD audit trails
+        continue-on-error: true
+        run: |
+          dart run runtime_ci_tooling:manage_cicd merge-audit-trails \
+            --incoming-dir .cicd_runs_incoming \
+            --output-dir .cicd_runs
+
+      - name: Archive audit trail
+        run: |
+          dart run runtime_ci_tooling:manage_cicd archive-run \
+            --version "${{ needs.determine-version.outputs.new_version }}"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd create-release \
+            --version "${{ needs.determine-version.outputs.new_version }}" \
+            --prev-tag "${{ needs.determine-version.outputs.prev_tag }}" \
+            --artifacts-dir ./artifacts \
+            --repo "${{ github.repository }}"
+
+  # ============================================================================
+  # Job 7: Post-Release Triage
+  # ============================================================================
+  post-release-triage:
+    needs: [determine-version, create-release]
+    if: needs.determine-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git for HTTPS with Token
+        shell: bash
+        run: |
+          TOKEN="${{ secrets.TSAVO_AT_PIECES_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/open-runtime/".insteadOf "git@github.com:open-runtime/"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/pieces-app/".insteadOf "git@github.com:pieces-app/"
+
+      - name: Skip LFS for dependency clones
+        run: git lfs install --skip-smudge
+
+      - uses: dart-lang/setup-dart@v1.7.1
+        with:
+          sdk: "3.9.2"
+
+      - name: Cache Dart pub dependencies
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-dart-pub-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: ${{ runner.os }}-dart-pub-
+
+      - run: dart pub get
+
+      - uses: actions/setup-node@v6.2.0
+        with:
+          node-version: "22"
+
+      - run: npm install -g @google/gemini-cli@latest
+
+      - name: Cache Go modules (GitHub MCP server)
+        uses: actions/cache@v5.0.3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mcp-v1
+          restore-keys: ${{ runner.os }}-go-mcp-
+
+      - uses: actions/download-artifact@v7.0.0
+        continue-on-error: true
+        with:
+          name: issue-manifest
+          path: /tmp/
+
+      - name: Post-release triage
+        env:
+          GEMINI_API_KEY: ${{ secrets.CICD_GEMINI_API_KEY_OPEN_RUNTIME }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run runtime_ci_tooling:manage_cicd post-release-triage \
+            --version "${{ needs.determine-version.outputs.new_version }}" \
+            --release-tag "v${{ needs.determine-version.outputs.new_version }}" \
+            --release-url "https://github.com/${{ github.repository }}/releases/tag/v${{ needs.determine-version.outputs.new_version }}" \
+            --manifest /tmp/issue_manifest.json

--- a/.runtime_ci/autodoc.json
+++ b/.runtime_ci/autodoc.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.0.0",
+  "gemini_model": "gemini-3-1-pro-preview",
+  "max_concurrent": 3,
+  "modules": [
+    {
+      "id": "core",
+      "name": "Semaphore Core",
+      "source_paths": [
+        "lib/src/"
+      ],
+      "lib_paths": [
+        "lib/src/"
+      ],
+      "output_path": "doc/core/",
+      "generate": [
+        "quickstart",
+        "api_reference",
+        "examples"
+      ],
+      "hash": "",
+      "last_updated": null
+    },
+    {
+      "id": "unix",
+      "name": "Unix FFI Bindings",
+      "source_paths": [
+        "lib/src/ffi/unix.dart",
+        "lib/src/unix_semaphore.dart"
+      ],
+      "lib_paths": [
+        "lib/src/"
+      ],
+      "output_path": "doc/unix/",
+      "generate": [
+        "api_reference"
+      ],
+      "hash": "",
+      "last_updated": null
+    },
+    {
+      "id": "windows",
+      "name": "Windows FFI Bindings",
+      "source_paths": [
+        "lib/src/ffi/windows.dart",
+        "lib/src/windows_semaphore.dart"
+      ],
+      "lib_paths": [
+        "lib/src/"
+      ],
+      "output_path": "doc/windows/",
+      "generate": [
+        "api_reference"
+      ],
+      "hash": "",
+      "last_updated": null
+    }
+  ],
+  "templates": {
+    "quickstart": "scripts/prompts/autodoc_quickstart_prompt.dart",
+    "api_reference": "scripts/prompts/autodoc_api_reference_prompt.dart",
+    "examples": "scripts/prompts/autodoc_examples_prompt.dart"
+  }
+}

--- a/.runtime_ci/config.json
+++ b/.runtime_ci/config.json
@@ -1,0 +1,108 @@
+{
+  "repository": {
+    "name": "runtime_native_semaphores",
+    "owner": "open-runtime",
+    "triaged_label": "triaged",
+    "changelog_path": "CHANGELOG.md",
+    "release_notes_path": ".runtime_ci/release_notes"
+  },
+  "gcp": {
+    "project": ""
+  },
+  "sentry": {
+    "organization": "",
+    "projects": [],
+    "scan_on_pre_release": false,
+    "recent_errors_hours": 168
+  },
+  "release": {
+    "pre_release_scan_sentry": false,
+    "pre_release_scan_github": true,
+    "post_release_close_own_repo": true,
+    "post_release_close_cross_repo": false,
+    "post_release_comment_cross_repo": true,
+    "post_release_link_sentry": false
+  },
+  "cross_repo": {
+    "enabled": true,
+    "orgs": [
+      "open-runtime"
+    ],
+    "repos": [
+      {
+        "owner": "open-runtime",
+        "repo": "named_locks",
+        "relationship": "dependent"
+      },
+      {
+        "owner": "open-runtime",
+        "repo": "aot_monorepo",
+        "relationship": "dependent"
+      }
+    ],
+    "discovery": {
+      "enabled": true,
+      "search_orgs": [
+        "open-runtime"
+      ]
+    }
+  },
+  "labels": {
+    "type": [
+      "bug",
+      "feature-request",
+      "enhancement",
+      "documentation",
+      "question"
+    ],
+    "priority": [
+      "P0-critical",
+      "P1-high",
+      "P2-medium",
+      "P3-low"
+    ],
+    "area": [
+      "area/core",
+      "area/unix",
+      "area/windows",
+      "area/ffi",
+      "area/docs"
+    ]
+  },
+  "thresholds": {
+    "auto_close": 0.9,
+    "suggest_close": 0.7,
+    "comment": 0.5
+  },
+  "agents": {
+    "enabled": [
+      "code_analysis",
+      "pr_correlation",
+      "duplicate",
+      "sentiment",
+      "changelog"
+    ],
+    "conditional": {
+      "changelog": {
+        "require_file": "CHANGELOG.md"
+      }
+    }
+  },
+  "gemini": {
+    "flash_model": "gemini-3-flash-preview",
+    "pro_model": "gemini-3-1-pro-preview",
+    "max_turns": 100,
+    "max_concurrent": 4,
+    "max_retries": 3
+  },
+  "secrets": {
+    "gemini_api_key_env": "GEMINI_API_KEY",
+    "github_token_env": [
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "GITHUB_PAT"
+    ],
+    "sentry_token_env": "SENTRY_ACCESS_TOKEN",
+    "gcp_secret_name": ""
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,15 @@ homepage: https://pieces.app
 repository: https://github.com/open-runtime/native_semaphores
 version: 1.0.0-beta.7
 description: A library for creating and managing named semaphores in Dart using FFI across macOS, Linux, and Windows.
+publish_to: none
+
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ^3.9.0
 
+# NOTE: When used inside the aot_monorepo workspace, add
+# `resolution: workspace` here. It is intentionally omitted so this
+# package can also resolve standalone (e.g., in its own CI pipeline).
 
-# Explicitly declare that this package works on all desktop platforms.
 platforms:
   linux:
   macos:
@@ -18,6 +22,10 @@ dependencies:
   meta: ^1.15.0
 
 dev_dependencies:
+  runtime_ci_tooling:
+    git:
+      url: git@github.com:open-runtime/runtime_ci_tooling.git
+      tag_pattern: v{{version}}
+    version: ^0.6.0
   test: ^1.25.5
   safe_int_id: ^1.1.1
-

--- a/scripts/prompts/autodoc_api_reference_prompt.dart
+++ b/scripts/prompts/autodoc_api_reference_prompt.dart
@@ -1,0 +1,96 @@
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+/// Autodoc: API_REFERENCE.md generator for a Dart source module.
+///
+/// Usage:
+///   dart run scripts/prompts/autodoc_api_reference_prompt.dart <module_name> <source_dir> [lib_dir]
+
+void main(List<String> args) {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: autodoc_api_reference_prompt.dart <module_name> <source_dir> [lib_dir]',
+    );
+    exit(1);
+  }
+
+  final moduleName = args[0];
+  final sourceDir = args[1];
+
+  final dartFiles = _runSync(
+    'find $sourceDir -name "*.dart" -not -name "*.g.dart" -not -name "*.pb.dart" -not -name "*.pbenum.dart" -not -name "*.pbjson.dart" -not -name "*.pbgrpc.dart" -type f 2>/dev/null',
+  );
+  final allDartContent = StringBuffer();
+  for (final file in dartFiles.split('\n').where((f) => f.isNotEmpty)) {
+    allDartContent.writeln('// === $file ===');
+    allDartContent.writeln(_truncate(_runSync('cat "$file"'), 20000));
+    allDartContent.writeln();
+  }
+
+  final dartContent = _truncate(allDartContent.toString(), 60000);
+
+  print('''
+You are a documentation writer generating an API reference for the
+**$moduleName** module.
+
+## Source Code
+
+```dart
+$dartContent
+```
+
+## Instructions
+
+Generate an API_REFERENCE.md with these sections:
+
+### 1. Classes
+For EACH public class:
+- **ClassName** -- one-line description
+  - List key fields with types and descriptions
+  - List key methods with signatures and descriptions
+  - Note any factory constructors or named constructors
+
+### 2. Enums
+For EACH public enum:
+- **EnumName** -- what it represents
+  - List all values with descriptions
+
+### 3. Extensions
+For EACH public extension:
+- **ExtensionName** on **TargetType** -- what it adds
+  - List methods/getters with descriptions
+
+### 4. Top-Level Functions
+For EACH public function:
+- **functionName** -- signature and description
+  - Parameters and return type
+
+## Rules
+- Use ONLY names that appear in the source code above
+- Do NOT fabricate fields, methods, or class names
+- Group related types together
+- Keep descriptions concise but informative
+
+Generate the complete API_REFERENCE.md content.
+''');
+}
+
+String _runSync(String command) {
+  try {
+    final result = Process.runSync(
+      'sh',
+      ['-c', command],
+      workingDirectory: Directory.current.path,
+    );
+    if (result.exitCode == 0) return (result.stdout as String).trim();
+    return '';
+  } catch (_) {
+    return '';
+  }
+}
+
+String _truncate(String input, int maxChars) {
+  if (input.length <= maxChars) return input;
+  return '${input.substring(0, maxChars)}\n\n... [TRUNCATED]\n';
+}

--- a/scripts/prompts/autodoc_examples_prompt.dart
+++ b/scripts/prompts/autodoc_examples_prompt.dart
@@ -1,0 +1,118 @@
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+/// Autodoc: EXAMPLES.md generator for a Dart source module.
+///
+/// Usage:
+///   dart run scripts/prompts/autodoc_examples_prompt.dart <module_name> <source_dir> [lib_dir]
+
+void main(List<String> args) {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: autodoc_examples_prompt.dart <module_name> <source_dir> [lib_dir]',
+    );
+    exit(1);
+  }
+
+  final moduleName = args[0];
+  final sourceDir = args[1];
+  final libDir = args.length > 2 ? args[2] : '';
+
+  final classes = _runSync(
+    'grep -rn "^class\\|^abstract class\\|^mixin" $sourceDir 2>/dev/null | head -30',
+  );
+  final methods = _runSync(
+    'grep -rn "Future<\\|Stream<\\|void " $sourceDir 2>/dev/null | grep -v "^\\/\\/" | head -30',
+  );
+  final enums = _runSync(
+    'grep -rn "^enum" $sourceDir 2>/dev/null',
+  );
+
+  String testContent = '(no tests found)';
+  final testDir = libDir.isNotEmpty ? libDir.replaceFirst('lib/', 'test/') : '';
+  if (testDir.isNotEmpty && Directory(testDir).existsSync()) {
+    testContent = _truncate(
+      _runSync(
+        'find $testDir -name "*_test.dart" -exec head -50 {} \\; 2>/dev/null',
+      ),
+      10000,
+    );
+  }
+
+  final commands = _runSync(
+    'grep -rn "extends Command" $sourceDir 2>/dev/null | head -20',
+  );
+
+  print('''
+You are writing practical code examples for the **$moduleName** module.
+
+## Classes
+```
+$classes
+```
+
+## Key Methods
+```
+$methods
+```
+
+## Enums
+```
+$enums
+```
+
+## CLI Commands
+```
+$commands
+```
+
+${testContent != '(no tests found)' ? '## Existing Test Patterns\n```dart\n$testContent\n```' : ''}
+
+## Instructions
+
+Generate an EXAMPLES.md with practical, copy-paste-ready examples:
+
+### 1. Basic Usage
+- Instantiate key classes
+- Call important methods
+- Show builder/configuration patterns
+
+### 2. Common Workflows
+- Typical end-to-end usage patterns
+- Integration with other components
+
+### 3. Error Handling
+- Common error patterns and how to handle them
+
+### 4. Advanced Usage
+- Less common but powerful patterns
+
+## Rules
+- Use ONLY real class/method names from the source code
+- Every code block must be valid, compilable Dart
+- Show complete, runnable examples (not fragments)
+- Include comments explaining what each step does
+
+Generate the complete EXAMPLES.md content.
+''');
+}
+
+String _runSync(String command) {
+  try {
+    final result = Process.runSync(
+      'sh',
+      ['-c', command],
+      workingDirectory: Directory.current.path,
+    );
+    if (result.exitCode == 0) return (result.stdout as String).trim();
+    return '';
+  } catch (_) {
+    return '';
+  }
+}
+
+String _truncate(String input, int maxChars) {
+  if (input.length <= maxChars) return input;
+  return '${input.substring(0, maxChars)}\n\n... [TRUNCATED]\n';
+}

--- a/scripts/prompts/autodoc_quickstart_prompt.dart
+++ b/scripts/prompts/autodoc_quickstart_prompt.dart
@@ -1,0 +1,138 @@
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+/// Autodoc: QUICKSTART.md generator for a Dart source module.
+///
+/// Usage:
+///   dart run scripts/prompts/autodoc_quickstart_prompt.dart <module_name> <source_dir> [lib_dir]
+
+void main(List<String> args) {
+  if (args.length < 2) {
+    stderr.writeln(
+      'Usage: autodoc_quickstart_prompt.dart <module_name> <source_dir> [lib_dir]',
+    );
+    exit(1);
+  }
+
+  final moduleName = args[0];
+  final sourceDir = args[1];
+  final libDir = args.length > 2 ? args[2] : '';
+
+  final sourceTree = _runSync(
+    'tree $sourceDir -L 3 --dirsfirst 2>/dev/null || find $sourceDir -name "*.dart" | head -30',
+  );
+  final dartFiles = _runSync('find $sourceDir -name "*.dart" -type f 2>/dev/null');
+  final dartCount = _runSync('find $sourceDir -name "*.dart" -type f 2>/dev/null | wc -l');
+
+  final firstDart = _runSync(
+    'find $sourceDir -name "*.dart" -not -name "*.g.dart" -not -name "*.pb.dart" -not -name "*.pbenum.dart" -not -name "*.pbjson.dart" -not -name "*.pbgrpc.dart" -type f 2>/dev/null | head -1',
+  );
+  final dartPreview = firstDart.isNotEmpty
+      ? _truncate(_runSync('cat "$firstDart"'), 15000)
+      : '(no Dart files)';
+
+  final classes = _runSync(
+    'grep -rn "^class\\|^abstract class\\|^mixin\\|^extension" $sourceDir 2>/dev/null | head -30',
+  );
+  final exports = _runSync(
+    'grep -rn "^export" $sourceDir 2>/dev/null | head -20',
+  );
+
+  String libTree = '(same as source)';
+  if (libDir.isNotEmpty && libDir != sourceDir && Directory(libDir).existsSync()) {
+    libTree = _runSync(
+      'tree $libDir -L 2 --dirsfirst -I "*.g.dart" 2>/dev/null || echo "(no tree)"',
+    );
+  }
+
+  print('''
+You are a documentation writer for the **$moduleName** module.
+
+Your job is to write a QUICKSTART.md that helps a developer get started
+with this module in under 5 minutes.
+
+## Module Structure
+
+### Source Files ($dartCount files)
+```
+$sourceTree
+```
+
+### File List
+```
+$dartFiles
+```
+
+### Library Structure
+```
+$libTree
+```
+
+### Classes and Extensions
+```
+$classes
+```
+
+### Exports
+```
+$exports
+```
+
+## Source Preview (first file)
+```dart
+$dartPreview
+```
+
+## Instructions
+
+Write a QUICKSTART.md with these sections:
+
+### 1. Overview
+- What this module does (2-3 sentences)
+- What APIs or utilities it provides
+
+### 2. Import
+Show the REAL import paths based on the lib directory structure.
+
+### 3. Setup
+Show how to instantiate key classes or configure the module.
+Use REAL class names from the source code.
+
+### 4. Common Operations
+3-5 code examples showing the most useful operations.
+
+### 5. Configuration
+Any configuration files, environment variables, or options.
+
+### 6. Related Modules
+List any related modules if applicable.
+
+## Rules
+- Use ONLY real class/method/field names from the source code
+- Do NOT fabricate API names or import paths
+- Code examples must be valid Dart that would compile
+- Keep it concise -- this is a QUICKSTART, not a full reference
+
+Generate the complete QUICKSTART.md content.
+''');
+}
+
+String _runSync(String command) {
+  try {
+    final result = Process.runSync(
+      'sh',
+      ['-c', command],
+      workingDirectory: Directory.current.path,
+    );
+    if (result.exitCode == 0) return (result.stdout as String).trim();
+    return '(command failed)';
+  } catch (_) {
+    return '(unavailable)';
+  }
+}
+
+String _truncate(String input, int maxChars) {
+  if (input.length <= maxChars) return input;
+  return '${input.substring(0, maxChars)}\n\n... [TRUNCATED: ${input.length - maxChars} chars omitted]\n';
+}


### PR DESCRIPTION
## Summary
- Add `runtime_ci_tooling` as a dev dependency with git source
- Add `.runtime_ci/config.json` and `autodoc.json` configuration
- Add CI workflow (analyze + test via runtime_ci_tooling)
- Add 7-job release pipeline with Gemini-powered versioning and changelog
- Add issue triage workflow with `@gemini-cli` support
- Add autodoc prompt templates for automated documentation generation
- Bump SDK constraint to `^3.9.0`, add `publish_to: none`

Existing platform test workflows (`workflow.yaml`, `reusable-native-semaphore-platform-tester.yaml`) are preserved unchanged.

## Test plan
- [ ] Verify `dart pub get` resolves all dependencies
- [ ] Verify CI workflow triggers and passes on this PR
- [ ] Verify existing platform test workflows still trigger correctly
- [ ] After merge: verify release pipeline skips for `chore:` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)