### PR TITLE
fix: add Abi.linuxArm (32-bit) mapping for mode_t

### DIFF
--- a/lib/src/ffi/unix.dart
+++ b/lib/src/ffi/unix.dart
@@ -44,6 +44,7 @@ typedef sem_t = Int;
   Abi.linuxX64: Uint16(),
   Abi.linuxIA32: Uint16(),
   Abi.linuxArm64: Uint16(),
+  Abi.linuxArm: Uint16(),
 })
 final class mode_t extends AbiSpecificInteger {
   const mode_t();


### PR DESCRIPTION
## Summary
- Adds the missing `Abi.linuxArm` (32-bit ARM) mapping for `mode_t` in `lib/src/ffi/unix.dart`
- Complements the `Abi.linuxArm64` mapping added in PR #17
- Without this, AOT compilation fails on 32-bit ARM Linux targets (e.g., older Raspberry Pi)

## Origin
Cherry-picked from [al-the-bear/tom_rt_native_semaphores](https://github.com/al-the-bear/tom_rt_native_semaphores).

### Fork Review Summary
The upstream fork (`al-the-bear/tom_rt_native_semaphores`) was comprehensively reviewed. Out of ~2,100 lines of diff across 41 files, the changes break down as:

| Category | Action |
|----------|--------|
| Package renaming (`runtime_native_semaphores` → `tom_rt_native_semaphores`) | Excluded |
| `dart format` reformatting (~1,900 lines) | Excluded |
| Deleted our CI/tooling infrastructure (`.runtime_ci/`, `.gemini/`, workflows) | Excluded |
| Added fork-specific files (`tom_repository.yaml`, `tom_build_state.json`, `version.versioner.dart`) | Excluded |
| **`Abi.linuxArm: Uint16()` added to `mode_t` mapping** | **This PR** |
| Removed `// ignore: unused_element` comments | Skipped (would re-introduce linter warnings) |
| Unused imports added speculatively | Excluded |
| Windows indentation regression | Excluded |

## Test plan
- [ ] CI passes (analyze + test on ubuntu-latest)
- [ ] Verify `mode_t` ABI mapping covers all supported Linux targets (x64, IA32, arm64, arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)